### PR TITLE
Add the theme-color meta attribute

### DIFF
--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -4,6 +4,7 @@
 		<title>Schedules | Changelog</title>
 
 		<meta charset="utf-8">
+		<meta name="theme-color" content="#13323C">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		
 		<link rel="shortcut icon" type="image/x-icon" href="/static/img/favicon.ico" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
 		<title>Schedules{% if schedule_valid %} | {{ schedule_name }}{% endif %}</title>
 
 		<meta charset="utf-8">
+		<meta name="theme-color" content="#13323C">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		
 		<link rel="shortcut icon" type="image/x-icon" href="/static/img/favicon.ico" />


### PR DESCRIPTION
Like the title says, add the `theme-color` meta attribute to both templates (`index.html` and `changelog.html`)