### PR TITLE
Fix the "Feature Requests" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The app for all schedules
 
-## [Feature Requests](https://github.com/hkamran80/schedules/issues?q=is%3Aissue+is%3Aopen+label%3A%22Feature+Request%22)
+## [Enhancements](https://github.com/hkamran80/schedules/issues?q=is%3Aissue+is%3Aopen+label%3A%22Enhancement%22)
 
 ## Changelog
 * Version 3.0.0 (January 13, 2020):


### PR DESCRIPTION
The "Feature Requests" link on the README has been broken, ever since the issue label "Feature Request" was renamed to "Enhancement". This PR (and accompanying branch) fix that, by fixing the link and by renaming the header to "Enhancements".