### PR TITLE
Version 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The app for all schedules
 ## [Enhancements](https://github.com/hkamran80/schedules/issues?q=is%3Aissue+is%3Aopen+label%3A%22Enhancement%22)
 
 ## Changelog
+* Version 3.0.1 (February 26, 2020):
+  * Fix the "Feature Requests" link on the README
+  * Drop the runtime version down to Python 3.7.6 (the `heroku-18` stack doesn't support 3.7.7, here's a [useful link](https://devcenter.heroku.com/articles/python-support#specifying-a-python-version))
+  * Change the `/changelog` endpoint to redirect to the GitHub README changelog, instead of the built-in web one (may be replaced later on)
 * Version 3.0.0 (January 13, 2020):
   * Add `hh:mm:ss` countdown
   * Add generic 404 page

--- a/main.py
+++ b/main.py
@@ -65,9 +65,7 @@ def schedule(schedule_id):
 
 @app.route("/changelog", methods=["GET"])
 def view_changelog():
-	changelog = json.loads(open("changelog.json").read())
-	
-	return render_template("changelog.html", versions=list(changelog.keys()), changelog=changelog)
+	return redirect("https://github.com/hkamran80/schedules/blob/master/README.md#changelog")
 
 if __name__ == "__main__":
 	if len(sys.argv) > 1 and sys.argv[1] == "--ci":

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.7
+python-3.7.6


### PR DESCRIPTION
This release of Schedules is very minor. The changes are as follows:
* Dropped the Python runtime version down to 3.7.6 ([explanation](https://devcenter.heroku.com/articles/python-support#specifying-a-python-version))
* Redirect the changelog endpoint to the GitHub README
* Fix the "Feature Requests" issue label link on the README