### PR TITLE
Add the AUHSD DLS color

### DIFF
--- a/static/css/schedule-colors.css
+++ b/static/css/schedule-colors.css
@@ -6,7 +6,7 @@
   background-color: #a80000;
   color: #ffffff;
 }
-.color--un-average-workday {
-  background-color: #188f24;
+.color--ca-auhsd-dls {
+  background-color: #343254;
   color: #ffffff;
 }


### PR DESCRIPTION
* Adds the color for the AUHSD DLS schedule
    * Color is picked from the header on the AUHSD website
* Removes the `un-average-workday` color