### PR TITLE
First GitHub Action: RDPWA Auditor

### DIFF
--- a/.github/workflows/rdpwa_auditor.yml
+++ b/.github/workflows/rdpwa_auditor.yml
@@ -1,0 +1,21 @@
+name: Site Auditor (RD-PWA)
+on:
+  push:
+    branches:
+      - redesigned-pwa
+  pull_request:
+    branches:
+      - redesigned-pwa
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Audit Live Site
+      uses: jakejarvis/lighthouse-action@master
+      with:
+        url: 'https://schedules.unisontech.org'
+    - name: Upload Results as Artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: Lighthouse Report
+        path: './report'


### PR DESCRIPTION
Uses Lighthouse to audit the `redesigned-pwa` branch, currently the production release of Schedules. This branch will eventually be merged into `main`.