### PR TITLE
Customizable period names, updates, remove unnecessary code/libraries, other little things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pnpm-debug.log*
 .dccache
 
 changes/
+changes.txt
 audits/
 
 tmp*

--- a/changes.txt
+++ b/changes.txt
@@ -1,1 +1,0 @@
-- Fix workflow (URL, artifact name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1611,6 +1611,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
+      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -1699,11 +1709,6 @@
         "cssnano-preset-default": "^4.0.0",
         "postcss": "^7.0.0"
       }
-    },
-    "@mdi/font": {
-      "version": "5.8.55",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.8.55.tgz",
-      "integrity": "sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -1889,6 +1894,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/mime": {
@@ -2834,6 +2845,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2858,6 +2879,19 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "get-intrinsic": "^1.0.1",
+        "is-string": "^1.0.5"
+      }
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2878,6 +2912,29 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -2947,6 +3004,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -3011,6 +3074,18 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+      "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+      "dev": true
+    },
+    "axobject-query": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
     },
     "babel-eslint": {
@@ -3780,11 +3855,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "clear-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clear-cache/-/clear-cache-1.0.1.tgz",
-      "integrity": "sha512-3Cr59jFcH3ENES1XDx0IL05C/LI02JFCn/pLt15wK3c4MOXnwo5XT+s7vTiPqvEsAgyyjeICilTQf4XdCgWaAQ=="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4070,6 +4140,12 @@
         "typedarray": "^0.0.6"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "dev": true
+    },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -4095,6 +4171,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -4327,6 +4409,12 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
+      "integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4634,6 +4722,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+      "dev": true
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+      "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
       "dev": true
     },
     "dashdash": {
@@ -5409,6 +5503,28 @@
         }
       }
     },
+    "eslint-config-airbnb": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
+      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^14.2.1",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.2"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.2"
+      }
+    },
     "eslint-config-prettier": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
@@ -5416,6 +5532,33 @@
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "eslint-loader": {
@@ -5431,6 +5574,166 @@
         "rimraf": "^2.6.1"
       }
     },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+      "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.1",
+        "ast-types-flow": "^0.0.7",
+        "axe-core": "^4.0.2",
+        "axobject-query": "^2.2.0",
+        "damerau-levenshtein": "^1.0.6",
+        "emoji-regex": "^9.0.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^3.1.0",
+        "language-tags": "^1.0.5"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+          "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
@@ -5439,6 +5742,52 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
+    },
+    "eslint-plugin-react": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
+      "integrity": "sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flatmap": "^1.2.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "object.entries": "^1.1.2",
+        "object.fromentries": "^2.0.2",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.18.1",
+        "string.prototype.matchall": "^4.0.2"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.0.tgz",
+      "integrity": "sha512-YKBY+kilK5wrwIdQnCF395Ya6nDro3EAMoe+2xFkmyklyhF16fH83TrQOo9zbZIDxBsXFgBbywta/0JKRNFDkw==",
+      "dev": true
     },
     "eslint-plugin-vue": {
       "version": "6.2.2",
@@ -6983,6 +7332,38 @@
         }
       }
     },
+    "internal-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
+      "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -7090,6 +7471,15 @@
         "hsla-regex": "^1.0.0",
         "rgb-regex": "^1.0.1",
         "rgba-regex": "^1.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -7272,6 +7662,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-svg": {
@@ -7497,6 +7893,16 @@
         "verror": "1.10.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -7514,6 +7920,21 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
+    },
+    "language-subtag-registry": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+      "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
+      "dev": true
+    },
+    "language-tags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+      "dev": true,
+      "requires": {
+        "language-subtag-registry": "~0.3.2"
+      }
     },
     "launch-editor": {
       "version": "2.2.1",
@@ -7549,6 +7970,35 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -7719,6 +8169,15 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -8396,6 +8855,30 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
@@ -9507,6 +9990,17 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -9673,6 +10167,12 @@
         "unpipe": "1.0.0"
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -9683,6 +10183,93 @@
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
         "type-fest": "^0.6.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -10402,6 +10989,17 @@
         "rechoir": "^0.6.2"
       }
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -10872,6 +11470,21 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string.prototype.matchall": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has-symbols": "^1.0.1",
+        "internal-slot": "^1.0.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
@@ -10928,6 +11541,12 @@
           "dev": true
         }
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-comments": {
       "version": "1.0.2",
@@ -11348,6 +11967,29 @@
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "serve:mock": "vue-cli-service build; serve -s dist -l 8090 --ssl-cert /Users/hkamran/Desktop/Desktop/Projects/Sites/certificates/server.crt --ssl-key /Users/hkamran/Desktop/Desktop/Projects/Sites/certificates/server.key"
   },
   "dependencies": {
-    "@mdi/font": "^5.8.55",
-    "clear-cache": "^1.0.1",
     "core-js": "^3.8.2",
     "register-service-worker": "^1.7.2",
     "roboto-fontface": "*",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*      /index.html     200
+/robots.txt     /robots.txt     200
+/*              /index.html     200

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,21 @@
             <v-container fluid>
                 <navigation-bar :schedules="schedules" />
                 <router-view :schedules="schedules" />
+
+                <v-snackbar bottom right :value="updateExists" :timeout="-1">
+                    An update is available for Schedules!
+
+                    <template v-slot:action="{ attrs }">
+                        <v-btn
+                            text
+                            color="primary"
+                            @click="refreshApp"
+                            v-bind="attrs"
+                        >
+                            Update
+                        </v-btn>
+                    </template>
+                </v-snackbar>
             </v-container>
         </v-main>
     </v-app>
@@ -11,6 +26,7 @@
 
 <script>
 import NavigationBar from "@/components/NavigationBar.vue";
+import update from "./mixins/update";
 import schedules from "@/schedules.json";
 
 export default {
@@ -22,122 +38,7 @@ export default {
     components: {
         NavigationBar
     },
-    methods: {
-        toggle_dark_mode: function() {
-            this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
-            localStorage.setItem(
-                "dark_theme",
-                this.$vuetify.theme.dark.toString()
-            );
-        },
-        tmp: function() {
-            console.log(JSON.stringify(this.schedules));
-        }
-    },
-    created() {
-        // Preferences
-        const theme = localStorage.getItem("dark_theme");
-        if (theme) {
-            // deepcode ignore UseStrictEquality: Loaded as a String, not a Boolean
-            if (theme == "true") {
-                this.$vuetify.theme.dark = true;
-            } else {
-                this.$vuetify.theme.dark = false;
-            }
-        } else if (
-            window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches
-        ) {
-            this.$vuetify.theme.dark = true;
-            localStorage.setItem(
-                "dark_theme",
-                this.$vuetify.theme.dark.toString()
-            );
-        }
-
-        const _allow_one_hour = localStorage.getItem("allow_one_hour");
-        if (_allow_one_hour) {
-            if (_allow_one_hour == "true") {
-                this.$allow_one_hour_notification = true;
-            } else {
-                this.$allow_one_hour_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_one_hour", "true");
-        }
-
-        const _allow_thirty_minute = localStorage.getItem(
-            "allow_thirty_minute"
-        );
-        if (_allow_thirty_minute) {
-            if (_allow_thirty_minute == "true") {
-                this.$allow_thirty_minute_notification = true;
-            } else {
-                this.$allow_thirty_minute_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_thirty_minutes", "true");
-        }
-
-        const _allow_fifteen_minute = localStorage.getItem(
-            "allow_fifteen_minute"
-        );
-        if (_allow_fifteen_minute) {
-            if (_allow_fifteen_minute == "true") {
-                this.$allow_fifteen_minute_notification = true;
-            } else {
-                this.$allow_fifteen_minute_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_fifteen_minutes", "true");
-        }
-
-        const _allow_ten_minute = localStorage.getItem("allow_ten_minute");
-        if (_allow_ten_minute) {
-            if (_allow_ten_minute == "true") {
-                this.$allow_ten_minute_notification = true;
-            } else {
-                this.$allow_ten_minute_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_ten_minutes", "true");
-        }
-
-        const _allow_five_minute = localStorage.getItem("allow_five_minute");
-        if (_allow_five_minute) {
-            if (_allow_five_minute == "true") {
-                this.$allow_five_minute_notification = true;
-            } else {
-                this.$allow_five_minute_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_five_minutes", "true");
-        }
-
-        const _allow_one_minute = localStorage.getItem("allow_one_minute");
-        if (_allow_one_minute) {
-            if (_allow_one_minute == "true") {
-                this.$allow_one_minute_notification = true;
-            } else {
-                this.$allow_one_minute_notification = false;
-            }
-        } else {
-            localStorage.setItem("allow_one_minute", "true");
-        }
-
-        const _allow_thirty_seconds = localStorage.getItem(
-            "allow_thirty_seconds"
-        );
-        if (_allow_thirty_seconds) {
-            if (_allow_thirty_seconds == "true") {
-                this.$allow_thirty_second_notification = true;
-            } else {
-                this.$allow_thirty_second_notification = false;
-            }
-        } else {
-            localStorage.setItem("_allow_thirty_seconds", "true");
-        }
-    }
+    mixins: [update]
 };
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,4 +80,11 @@ export default {
 a {
     text-decoration: none;
 }
+
+/* Global Classes */
+.text-wrap--break {
+    display: inline-block;
+    word-break: break-word;
+    word-wrap: break-word;
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,12 +33,38 @@ export default {
     name: "App",
     data: () => ({
         debug: false,
-        schedules: schedules
+        schedules: schedules,
+        base_document_title: "Schedules"
     }),
     components: {
         NavigationBar
     },
-    mixins: [update]
+    mixins: [update],
+    created() {
+        if (this.$beta_mode) {
+            this.base_document_title = "Schedules (beta)";
+        } else if (this.$dev_mode) {
+            this.base_document_title = "Schedules (dev)";
+        }
+    },
+    watch: {
+        $route(to) {
+            if (to.name === "Home") {
+                document.title = this.base_document_title;
+            } else if (
+                to.name === "Schedule" &&
+                typeof this.schedules[to.params.id] !== "undefined"
+            ) {
+                document.title = `${this.base_document_title} | ${
+                    this.schedules[to.params.id].name
+                }`;
+            } else if (to.name === "NotFound") {
+                document.title = `${this.base_document_title} | Page Not Found`;
+            } else {
+                document.title = this.base_document_title;
+            }
+        }
+    }
 };
 </script>
 

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -3,7 +3,9 @@
         <v-row id="navigation" no-gutters>
             <v-col align-self="center" justify="center" md="8" cols="12">
                 <router-link to="/">
-                    <h1 color="primary">Schedules</h1>
+                    <h1 color="primary">
+                        Schedules <span v-if="$beta_mode">(beta)</span>
+                    </h1>
                 </router-link>
             </v-col>
             <v-col
@@ -58,55 +60,6 @@
                         inset
                         @click="toggle_theme"
                     />
-                    <!-- TODO: Fix 24-hour time switch -->
-                    <!--<v-switch
-                        label="24-Hour Time"
-                        v-model="$twenty_four_hour_time"
-                        readonly
-                        inset
-                        @click="toggle_twenty_four_hour_time"
-                    />
-
-                    <v-divider />
-
-                    <v-subheader>Notifications</v-subheader>
-                    <v-switch
-                        label="One Hour Notifications"
-                        v-model="$allow_one_hour_notification"
-                        readonly
-                        inset
-                        @click="toggle_one_hour"
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_thmn"
-                        label="Thirty Minute Notifications"
-                        inset
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_fimn"
-                        label="Fifteen Minute Notifications"
-                        inset
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_tmn"
-                        label="Ten Minute Notifications"
-                        inset
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_fmn"
-                        label="Five Minute Notifications"
-                        inset
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_omn"
-                        label="One Minute Notifications"
-                        inset
-                    ></v-switch>
-                    <v-switch
-                        v-model="toggle_thsn"
-                        label="Thirty Second Notifications"
-                        inset
-                    ></v-switch>-->
                 </v-card-text>
             </v-card>
         </v-dialog>
@@ -149,22 +102,6 @@ export default {
             localStorage.setItem(
                 "dark_theme",
                 this.$vuetify.theme.dark.toString()
-            );
-        },
-        toggle_twenty_four_hour_time: function() {
-            this.$twenty_four_hour_time = !this.$twenty_four_hour_time;
-            console.log(this.$twenty_four_hour_time);
-            localStorage.setItem(
-                "twenty_four_hour_time",
-                this.$twenty_four_hour_time.toString()
-            );
-        },
-        toggle_one_hour: function() {
-            this.$allow_one_hour_notification = !this
-                .$allow_one_hour_notification;
-            localStorage.setItem(
-                "allow_one_hour",
-                this.$allow_one_hour_notification.toString()
             );
         }
     }

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -5,6 +5,7 @@
                 <router-link to="/">
                     <h1 color="primary">
                         Schedules <span v-if="$beta_mode">(beta)</span>
+                        <span v-if="$dev_mode">(dev)</span>
                     </h1>
                 </router-link>
             </v-col>
@@ -28,41 +29,16 @@
                 <v-btn
                     icon
                     class="navigation-item"
-                    title="Open Preferences"
-                    aria-label="Open Preferences"
-                    @click="settings = true"
+                    title="Toggle Theme"
+                    aria-label="Toggle Theme"
+                    @click="toggle_theme"
                 >
                     <v-icon color="primary">
-                        mdi-cog-outline
+                        mdi-theme-light-dark
                     </v-icon>
                 </v-btn>
             </v-col>
         </v-row>
-
-        <v-dialog v-model="settings" scrollable max-width="500">
-            <v-card>
-                <v-card-title class="headline">
-                    <v-row no-gutters>
-                        <v-col> Preferences </v-col>
-                        <v-col cols="2" class="text-right">
-                            <v-btn icon @click="settings = false">
-                                <v-icon color="primary">mdi-close</v-icon>
-                            </v-btn>
-                        </v-col>
-                    </v-row>
-                </v-card-title>
-
-                <v-card-text>
-                    <v-switch
-                        label="Dark Theme"
-                        v-model="$vuetify.theme.dark"
-                        readonly
-                        inset
-                        @click="toggle_theme"
-                    />
-                </v-card-text>
-            </v-card>
-        </v-dialog>
     </div>
 </template>
 
@@ -71,11 +47,6 @@ export default {
     name: "NavigationBar",
     props: {
         schedules: Object
-    },
-    data: function() {
-        return {
-            settings: false
-        };
     },
     mounted() {
         const theme = localStorage.getItem("dark_theme");

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -1,0 +1,76 @@
+const _allow_one_hour = localStorage.getItem("allow_one_hour");
+if (_allow_one_hour) {
+    if (_allow_one_hour == "true") {
+        this.$allow_one_hour_notification = true;
+    } else {
+        this.$allow_one_hour_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_one_hour", "true");
+}
+
+const _allow_thirty_minute = localStorage.getItem("allow_thirty_minute");
+if (_allow_thirty_minute) {
+    if (_allow_thirty_minute == "true") {
+        this.$allow_thirty_minute_notification = true;
+    } else {
+        this.$allow_thirty_minute_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_thirty_minutes", "true");
+}
+
+const _allow_fifteen_minute = localStorage.getItem("allow_fifteen_minute");
+if (_allow_fifteen_minute) {
+    if (_allow_fifteen_minute == "true") {
+        this.$allow_fifteen_minute_notification = true;
+    } else {
+        this.$allow_fifteen_minute_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_fifteen_minutes", "true");
+}
+
+const _allow_ten_minute = localStorage.getItem("allow_ten_minute");
+if (_allow_ten_minute) {
+    if (_allow_ten_minute == "true") {
+        this.$allow_ten_minute_notification = true;
+    } else {
+        this.$allow_ten_minute_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_ten_minutes", "true");
+}
+
+const _allow_five_minute = localStorage.getItem("allow_five_minute");
+if (_allow_five_minute) {
+    if (_allow_five_minute == "true") {
+        this.$allow_five_minute_notification = true;
+    } else {
+        this.$allow_five_minute_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_five_minutes", "true");
+}
+
+const _allow_one_minute = localStorage.getItem("allow_one_minute");
+if (_allow_one_minute) {
+    if (_allow_one_minute == "true") {
+        this.$allow_one_minute_notification = true;
+    } else {
+        this.$allow_one_minute_notification = false;
+    }
+} else {
+    localStorage.setItem("allow_one_minute", "true");
+}
+
+const _allow_thirty_seconds = localStorage.getItem("allow_thirty_seconds");
+if (_allow_thirty_seconds) {
+    if (_allow_thirty_seconds == "true") {
+        this.$allow_thirty_second_notification = true;
+    } else {
+        this.$allow_thirty_second_notification = false;
+    }
+} else {
+    localStorage.setItem("_allow_thirty_seconds", "true");
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import "vue-toastification/dist/index.css";
 
 Vue.config.productionTip = false;
 
+Vue.prototype.$dev_mode = process.env.NODE_ENV === "development";
 Vue.prototype.$beta_mode = process.env.VUE_APP_BETA_MODE === "true";
 
 Vue.prototype.$twenty_four_hour_time = false;

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,8 @@ import "vue-toastification/dist/index.css";
 
 Vue.config.productionTip = false;
 
+Vue.prototype.$beta_mode = process.env.VUE_APP_BETA_MODE === "true";
+
 Vue.prototype.$twenty_four_hour_time = false;
 Vue.prototype.$allow_one_hour_notification = true;
 Vue.prototype.$allow_thirty_minute_notification = true;

--- a/src/mixins/update.js
+++ b/src/mixins/update.js
@@ -1,0 +1,44 @@
+// Source: https://dev.to/drbragg/handling-service-worker-updates-in-your-vue-pwa-1pip
+export default {
+    data() {
+        return {
+            // Refresh Variables
+            refreshing: false,
+            registration: null,
+            updateExists: false
+        };
+    },
+
+    created() {
+        // Listen for our custom event from the SW registration
+        document.addEventListener("swUpdated", this.updateAvailable, {
+            once: true
+        });
+
+        // Prevent multiple refreshes
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+            if (this.refreshing) return;
+            this.refreshing = true;
+            // Here the actual reload of the page occurs
+            window.location.reload();
+        });
+    },
+
+    methods: {
+        // Store the SW registration so we can send it a message
+        // We use `updateExists` to control whatever alert, toast, dialog, etc we want to use
+        // To alert the user there is an update they need to refresh for
+        updateAvailable(event) {
+            this.registration = event.detail;
+            this.updateExists = true;
+        },
+        // Called when the user accepts the update
+        refreshApp() {
+            this.updateExists = false;
+            // Make sure we only send a 'skip waiting' message if the SW is waiting
+            if (!this.registration || !this.registration.waiting) return;
+            // send message to SW to skip the waiting and activate the new SW
+            this.registration.waiting.postMessage({ type: "SKIP_WAITING" });
+        }
+    }
+};

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 
 import { register } from "register-service-worker";
-import { clearCache } from "clear-cache";
 
 if (process.env.NODE_ENV === "production") {
     register(`${process.env.BASE_URL}service-worker.js`, {
@@ -19,10 +18,12 @@ if (process.env.NODE_ENV === "production") {
         },
         updatefound() {
             console.log("New content is downloading.");
-            clearCache(true);
         },
-        updated() {
+        updated(registration) {
             console.log("New content is available; please refresh.");
+            document.dispatchEvent(
+                new CustomEvent("swUpdated", { detail: registration })
+            );
         },
         offline() {
             console.log(

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,12 +8,12 @@ Vue.use(VueRouter);
 const routes = [
     {
         path: "/",
-        name: "home",
+        name: "Home",
         component: Home
     },
     {
         path: "/schedule/:id",
-        name: "schedule",
+        name: "Schedule",
         component: Schedule
     },
     {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,3 +4,10 @@ self.addEventListener("fetch", function(event) {});
 
 self.__precacheManifest = [].concat(__precacheManifest || []);
 workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
+
+// Source: https://dev.to/drbragg/handling-service-worker-updates-in-your-vue-pwa-1pip
+self.addEventListener("message", event => {
+    if (event.data && event.data.type === "SKIP_WAITING") {
+        self.skipWaiting();
+    }
+});

--- a/src/views/Schedule.vue
+++ b/src/views/Schedule.vue
@@ -58,8 +58,8 @@
         <v-dialog v-model="edit_dialog" width="750" scrollable>
             <v-card class="mx-auto">
                 <v-card-title>
-                    <v-row>
-                        <v-col>
+                    <v-row align="center">
+                        <v-col class="text-wrap--break">
                             Edit Period Names
                         </v-col>
                         <v-col cols="4" class="text-right">
@@ -73,6 +73,7 @@
                                     mdi-calendar-export
                                 </v-icon>
                             </v-btn>
+
                             <v-btn icon @click="save_period_names">
                                 <v-icon color="primary">
                                     mdi-content-save-outline
@@ -108,8 +109,8 @@
         <v-dialog v-model="pn_export_dialog" width="750">
             <v-card class="mx-auto">
                 <v-card-title>
-                    <v-row>
-                        <v-col>
+                    <v-row align="center">
+                        <v-col class="text-wrap--break">
                             Export Period Names
                         </v-col>
                         <v-col cols="4" class="text-right">
@@ -140,8 +141,8 @@
         <v-dialog v-model="pn_import.dialog" width="750">
             <v-card class="mx-auto">
                 <v-card-title>
-                    <v-row>
-                        <v-col>
+                    <v-row align="center">
+                        <v-col class="text-wrap--break">
                             Import Period Names
                         </v-col>
                         <v-col cols="4" class="text-right">
@@ -347,6 +348,7 @@ export default {
                 JSON.stringify(this.period_names)
             );
             this.edit_dialog = false;
+            this.show_toast("Saved period names!", "success");
         },
         get_period_names: function() {
             if (

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,7 +4,7 @@ module.exports = {
         config.plugin("html").tap(args => {
             args[0].title =
                 process.env.NODE_ENV === "development"
-                    ? "Schedules (beta)"
+                    ? "Schedules (dev)"
                     : "Schedules";
             return args;
         });
@@ -12,16 +12,16 @@ module.exports = {
     pwa: {
         name:
             process.env.NODE_ENV === "development"
-                ? "Schedules (beta)"
+                ? "Schedules (dev)"
                 : "Schedules",
-        themeColor: "#2c3e50",
+        themeColor: "#C2185B",
         workboxPluginMode: "InjectManifest",
         workboxOptions: {
             swSrc: "src/service-worker.js",
             exclude: [/\.map$/, /_redirects/]
         },
         manifestOptions: {
-            backgroundColor: "#2c3e50"
+            backgroundColor: "#C2185B"
         }
     }
 };


### PR DESCRIPTION
- Closes #4 (customizable period names)
- Adds update functionality through the service worker
    - Remove the npm package `clear-cache`
- Remove `@mdi/font` in favor of the stylesheet
- Remove preferences window and loading functionality
- Switch out preferences button for theme switcher
- Add document titling
- Add global text wrap on word break class
- Update PWA name when in development
- Update PWA theme color
- Add `robots.txt` to `_redirects`
- Add mode to header name (beta: "Schedules (beta)", dev: "Schedules (dev)")
- Make the 404 page work